### PR TITLE
fix: resolve ESLint errors in web frontend

### DIFF
--- a/web/src/components/ui/card.test.tsx
+++ b/web/src/components/ui/card.test.tsx
@@ -30,8 +30,8 @@ describe('Card Components', () => {
     })
 
     it('should forward ref', () => {
-      const ref = { current: null }
-      render(<Card ref={ref as any}>Content</Card>)
+      const ref = { current: null as HTMLDivElement | null }
+      render(<Card ref={ref}>Content</Card>)
       expect(ref.current).toBeTruthy()
     })
 

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from 'react';
 import { cn } from '@/lib/utils';
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+// InputProps extends React.InputHTMLAttributes to allow all standard input attributes
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { apiClient } from '@/utils/api';
 import type { ApiResponse } from '@/types';
 
@@ -14,7 +14,7 @@ export const useApi = <T>(
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const execute = async (): Promise<ApiResponse<T>> => {
+  const execute = useCallback(async (): Promise<ApiResponse<T>> => {
     setLoading(true);
     setError(null);
 
@@ -40,13 +40,13 @@ export const useApi = <T>(
     } finally {
       setLoading(false);
     }
-  };
+  }, [endpoint]);
 
   useEffect(() => {
     if (options.immediate) {
       execute();
     }
-  }, [endpoint, options.immediate]);
+  }, [execute, options.immediate]);
 
   return {
     data,

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -12,4 +12,8 @@ createRoot(document.getElementById('root')!).render(
 )
 
 // initialize analytics after app mounts
-initAnalytics((import.meta as any).env?.VITE_GA_ID || (env as any).analytics?.gaId || import.meta.env.VITE_GA_ID)
+const gaId = import.meta.env.VITE_GA_ID ||
+  (typeof env === 'object' && env !== null && 'analytics' in env &&
+   typeof env.analytics === 'object' && env.analytics !== null &&
+   'gaId' in env.analytics ? env.analytics.gaId : undefined);
+initAnalytics(gaId as string | undefined);

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -5,7 +5,7 @@
  */
 
 import '@testing-library/jest-dom'
-import { expect, afterEach, vi } from 'vitest'
+import { afterEach, vi } from 'vitest'
 import { cleanup } from '@testing-library/react'
 
 // Cleanup after each test case (e.g., clearing jsdom)
@@ -28,7 +28,7 @@ global.IntersectionObserver = class IntersectionObserver {
     return []
   }
   unobserve() {}
-} as any
+} as unknown as typeof global.IntersectionObserver
 
 // Mock window.matchMedia (for responsive components)
 Object.defineProperty(window, 'matchMedia', {

--- a/web/src/test/test-utils.tsx
+++ b/web/src/test/test-utils.tsx
@@ -21,7 +21,7 @@ import { render, RenderOptions } from '@testing-library/react'
  * })
  * ```
  */
-interface CustomRenderOptions extends Omit<RenderOptions, 'wrapper'> {
+type CustomRenderOptions = Omit<RenderOptions, 'wrapper'> & {
   // Add custom options here as needed
 }
 
@@ -44,5 +44,6 @@ export function renderWithProviders(
 }
 
 // Re-export everything from testing library
+// eslint-disable-next-line react-refresh/only-export-components
 export * from '@testing-library/react'
 export { renderWithProviders as render }

--- a/web/src/test/test-utils.tsx
+++ b/web/src/test/test-utils.tsx
@@ -5,8 +5,8 @@
  * for testing React components with common providers and setup.
  */
 
-import { ReactElement } from 'react'
-import { render, RenderOptions } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { render, type RenderOptions } from '@testing-library/react'
 
 /**
  * Custom render function that wraps components with common providers

--- a/web/src/utils/analytics.ts
+++ b/web/src/utils/analytics.ts
@@ -39,7 +39,6 @@ export const initAnalytics = async (measurementId: string | undefined): Promise<
     window.gtag('js', new Date());
     window.gtag('config', measurementId, { send_page_view: false, debug_mode: import.meta.env.DEV });
     if (import.meta.env.DEV) {
-      // eslint-disable-next-line no-console
       console.info('[analytics] config sent for', measurementId);
     }
     trackPageView();
@@ -48,7 +47,6 @@ export const initAnalytics = async (measurementId: string | undefined): Promise<
     // no-op; failed to load analytics
     // You can log to console for debugging in dev
     if (import.meta.env.DEV) {
-      // eslint-disable-next-line no-console
       console.warn('[analytics] failed to initialize', error);
     }
   }
@@ -64,7 +62,6 @@ export const trackPageView = (): void => {
       page_path: window.location.pathname,
     });
     if (import.meta.env.DEV) {
-      // eslint-disable-next-line no-console
       console.info('[analytics] page_view', { page_location: pageLocation });
     }
   } catch {


### PR DESCRIPTION
- Replace 'any' types with proper TypeScript types
- Fix empty interface declarations
- Add useCallback to fix React Hook dependency warning
- Remove unused eslint-disable directives
- Add proper eslint-disable for necessary cases