### PR TITLE
docs: add technical roadmap link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,10 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 - 🚀 **Submit PRs** → See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ### 📅 Roadmap
+
+📖 **[View our detailed Technical Roadmap](https://plotsenseai.gitbook.io/plotsense-technical-roadmap/)**
+
+Upcoming features:
 - More model integrations
 - Automated insight highlighting
 - Jupyter widget support


### PR DESCRIPTION
Add prominent link to PlotSense Technical Roadmap documentation in the Roadmap section. This provides users with detailed information about upcoming features and development plans.

Link: https://plotsenseai.gitbook.io/plotsense-technical-roadmap/